### PR TITLE
Minor rule updates to support our promise library

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ You can pass an `{ allowThen: true }` as an option to this rule
 You can pass a `{ terminationMethod: 'done' }` as an option to this rule
  to require `done()` instead of `catch()` at the end of the promise chain.
  This is useful for many non-standard Promise implementations.
+ 
+You can also pass an array of methods such as
+ `{ terminationMethod: ['catch',  'asCallback'] }`
 
 ### `always-return`
 

--- a/rules/catch-or-return.js
+++ b/rules/catch-or-return.js
@@ -33,6 +33,10 @@ module.exports = {
     var allowThen = options.allowThen
     var terminationMethod = options.terminationMethod || 'catch'
 
+    if (typeof terminationMethod === 'string') {
+      terminationMethod = [terminationMethod]
+    }
+
     return {
       ExpressionStatement: function (node) {
         if (!isPromise(node.expression)) {
@@ -52,7 +56,7 @@ module.exports = {
         // somePromise.catch()
         if (node.expression.type === 'CallExpression' &&
           node.expression.callee.type === 'MemberExpression' &&
-          node.expression.callee.property.name === terminationMethod
+          terminationMethod.indexOf(node.expression.callee.property.name) !== -1
         ) {
           return
         }

--- a/rules/param-names.js
+++ b/rules/param-names.js
@@ -2,21 +2,25 @@ module.exports = {
   create: function (context) {
     return {
       NewExpression: function (node) {
+
         if (node.callee.name === 'Promise' && node.arguments.length === 1) {
           var params = node.arguments[0].params
 
           if (!params || !params.length) { return }
 
-          if (params[0].name !== 'resolve') {
-            return context.report(node, 'Promise constructor\'s first parameter must be named resolve')
-          }
-
-          if (params[1] && params[1].name !== 'reject') {
-            return context.report(node, 'Promise constructor\'s second parameter must be named reject')
-          }
-
-          if (params[2] && params[2].name !== 'onCancel') {
-            return context.report(node, 'Promise constructor\'s third parameter must be named onCancel')
+          var defaults = ['resolve', 'reject']
+          for (var i = 0; i < params.length; i++) {
+            var actualName = params[i].name;
+            var expectedName = context.options[i] || defaults[i];
+            if (!expectedName || !expectedName.length) {
+              return context.report(node, 'Promise constructor has unexpected parameter ' + i + ' "' + actualName + '"')
+            }
+            if (typeof expectedName === 'string') {
+              expectedName = [expectedName]
+            }
+            if (expectedName.indexOf(actualName) === -1) {
+              return context.report(node, 'Promise constructor parameter ' + i + ' "' + actualName + '" must be named: ' + expectedName.join(", "))
+            }
           }
         }
       }

--- a/rules/param-names.js
+++ b/rules/param-names.js
@@ -2,7 +2,6 @@ module.exports = {
   create: function (context) {
     return {
       NewExpression: function (node) {
-
         if (node.callee.name === 'Promise' && node.arguments.length === 1) {
           var params = node.arguments[0].params
 

--- a/rules/param-names.js
+++ b/rules/param-names.js
@@ -8,11 +8,15 @@ module.exports = {
           if (!params || !params.length) { return }
 
           if (params[0].name !== 'resolve') {
-            return context.report(node, 'Promise constructor parameters must be named resolve, reject')
+            return context.report(node, 'Promise constructor\'s first parameter must be named resolve')
           }
 
           if (params[1] && params[1].name !== 'reject') {
-            return context.report(node, 'Promise constructor parameters must be named resolve, reject')
+            return context.report(node, 'Promise constructor\'s second parameter must be named reject')
+          }
+
+          if (params[2] && params[2].name !== 'onCancel') {
+            return context.report(node, 'Promise constructor\'s third parameter must be named onCancel')
           }
         }
       }

--- a/test/catch-or-return.test.js
+++ b/test/catch-or-return.test.js
@@ -42,8 +42,11 @@ ruleTester.run('catch-or-return', rule, {
     { code: 'frank.then(go).then(to).then(pewPew, jail)', options: [{ 'allowThen': true }] },
 
     // terminationMethod=done - .done(null, fn)
-    { code: 'frank().then(go).done()', options: [{ 'terminationMethod': 'done' }] }
+    { code: 'frank().then(go).done()', options: [{ 'terminationMethod': 'done' }] },
 
+    // terminationMethod=[catch, done] - .done(null, fn)
+    { code: 'frank().then(go).catch()', options: [{ 'terminationMethod': ['catch', 'done'] }] },
+    { code: 'frank().then(go).done()', options: [{ 'terminationMethod': ['catch', 'done'] }] }
   ],
 
   invalid: [

--- a/test/param-names.test.js
+++ b/test/param-names.test.js
@@ -6,23 +6,37 @@ var RuleTester = require('eslint').RuleTester
 var ruleTester = new RuleTester()
 ruleTester.run('param-names', rule, {
   valid: [
+    // defaults
     'new Promise(function(resolve, reject) { })',
     'new Promise(function(resolve) { })',
-    'new Promise(function(resolve, reject, onCancel) { })'
+
+    // options
+    { code: 'new Promise(function(resolve, reject) { })', options: ['resolve', 'reject']},
+    { code: 'new Promise(function(fulfill, reject, cancel) { })', options: [['resolve', 'fulfill'], 'reject', ['onCancel', 'cancel']]},
   ],
 
   invalid: [
     {
       code: 'new Promise(function(reject, resolve) { })',
-      errors: [ { message: 'Promise constructor\'s first parameter must be named resolve' } ]
+      errors: [ { message: 'Promise constructor parameter 0 "reject" must be named: resolve' } ]
     },
     {
       code: 'new Promise(function(resolve, rej) { })',
-      errors: [ { message: 'Promise constructor\'s second parameter must be named reject' } ]
+      errors: [ { message: 'Promise constructor parameter 1 "rej" must be named: reject' } ]
     },
     {
       code: 'new Promise(function(resolve, reject, cancelled) { })',
-      errors: [ { message: 'Promise constructor\'s third parameter must be named onCancel' } ]
+      errors: [ { message: 'Promise constructor has unexpected parameter 2 "cancelled"' } ]
+    },
+    {
+      code: 'new Promise(function(resolve, reject) { })',
+      options: ['fulfill', 'throw'],
+      errors: [ { message: 'Promise constructor parameter 0 "resolve" must be named: fulfill'  } ]
+    },
+    {
+      code: 'new Promise(function(reject, resolve) { })',
+      options: [['resolve', 'fulfill'], 'reject'],
+      errors: [ { message: 'Promise constructor parameter 0 "reject" must be named: resolve, fulfill'  } ]
     }
   ]
 })

--- a/test/param-names.test.js
+++ b/test/param-names.test.js
@@ -7,17 +7,22 @@ var ruleTester = new RuleTester()
 ruleTester.run('param-names', rule, {
   valid: [
     'new Promise(function(resolve, reject) { })',
-    'new Promise(function(resolve) { })'
+    'new Promise(function(resolve) { })',
+    'new Promise(function(resolve, reject, onCancel) { })'
   ],
 
   invalid: [
     {
       code: 'new Promise(function(reject, resolve) { })',
-      errors: [ { message: 'Promise constructor parameters must be named resolve, reject' } ]
+      errors: [ { message: 'Promise constructor\'s first parameter must be named resolve' } ]
     },
     {
       code: 'new Promise(function(resolve, rej) { })',
-      errors: [ { message: 'Promise constructor parameters must be named resolve, reject' } ]
+      errors: [ { message: 'Promise constructor\'s second parameter must be named reject' } ]
+    },
+    {
+      code: 'new Promise(function(resolve, reject, cancelled) { })',
+      errors: [ { message: 'Promise constructor\'s third parameter must be named onCancel' } ]
     }
   ]
 })


### PR DESCRIPTION
We use some non-standard APIs in our promise library.

This PR addresses 2 things:
1. We use `finally` in many places. This cherry picks a change from a later version of eslint-plugin-promise to allow the `catch-or-return` rule to terminate with multiple options. hbo/master is currently branched off of v2.0.1 due to dependencies we haven't updated yet.  
2. Adds options to the `param-names` rule to handle cancellation callbacks and conflicts with other eslint rules about renaming unused variables.